### PR TITLE
修正fgetcsv()无法正确识别UTF-8编码csv部分行的问题

### DIFF
--- a/analytic.php
+++ b/analytic.php
@@ -197,7 +197,8 @@ function inWhiteList($line) {
     return false;
 }
 
-while($line = fgetcsv($handle, 2048, ",")) {
+while($origline = fgets($handle)) { //fgetcsv can't treat UTF-8 characters properly under certain conditions
+	$line = explode(',', $origline);
     if (in_array('总流量(kb)', $line)) {
         $descIndex = array_flip($line);
         $trafficOffset = $descIndex['总流量(kb)'];


### PR DESCRIPTION
原生的fgetcsv()对于双字节字符的处理有点bug，如果csv的中文字符没有强制通过双引号前后括起来（也就是Excel默认的保存格式）会导致部分逗号无法被fgetcsv正确识别导致一部分流量详单漏掉。
目前导出的流量轨迹内容似乎并没有半角逗号，直接explode可以解决问题。

在PHP 7.11测试通过。